### PR TITLE
Install docker Python library

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,7 @@
-docker # Needed for molecule to work correctly
-flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
 #
-# Also install flake8, since it appears to be missing from the
-# dependencies for the bleeding edge molecule.
-# molecule
-git+https://github.com/ansible/molecule.git#egg=molecule
+# molecule[docker]
+git+https://github.com/ansible/molecule.git#egg=molecule[docker]
 pre-commit

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,4 +45,13 @@
 - name: Install docker-compose
   pip:
     executable: pip3
-    name: docker-compose
+    name:
+      - docker-compose
+
+# This is needed when using the Ansible modules docker_image,
+# docker_compose, etc.
+- name: Install docker python library
+  pip:
+    executable: pip3
+    name:
+      - docker


### PR DESCRIPTION
This Python library is required to use the Ansible modules `docker_image`, `docker_compose`, etc., so we may as well install it here instead of in each and every role where we use one of those modules.

Also go ahead and pull in upstream changes from cisagov/skeleton-ansible-role.