### PR TITLE
Use release-specific apt repo 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,13 +23,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.17.0
+    rev: v0.18.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.16.0
+    rev: v1.17.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -37,17 +37,17 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.7.8
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.19.0
+    rev: v1.23.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.1
+    rev: 1.6.2
     hooks:
       - id: bandit
         args:
@@ -57,7 +57,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.0a0
+    rev: v4.1.1a0
     hooks:
       - id: ansible-lint
         # files: molecule/default/playbook.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,33 @@
 ---
+# Based on ansible-lint config
 extends: default
 
 rules:
-  # yamllint doesn't like when we use yes and no for true and false,
-  # but that's pretty standard in Ansible.
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
   truthy: disable

--- a/files/docker.list
+++ b/files/docker.list
@@ -1,1 +1,0 @@
-deb [arch=amd64] https://download.docker.com/linux/debian stretch stable

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: First Last
   description: Skeleton Ansible role
-  company: CISA NCATS
+  company: CISA Cyber Assessments
   license: CC0
   min_ansible_version: 2.0
   platforms:

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,9 +6,17 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -5,12 +5,18 @@ Docker driver installation guide
 Requirements
 ============
 
-* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
 * Docker Engine
-* docker-py
-* docker
 
 Install
 =======
 
-    $ sudo pip install docker-py
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,6 +10,10 @@ platforms:
     image: debian:stretch-slim
   - name: debian10
     image: debian:buster-slim
+  - name: fedora29
+    image: fedora:29
+  - name: fedora30
+    image: fedora:30
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,9 @@
     id: 0EBFCD88
 
 - name: Copy sources list for official Docker package repo
-  copy:
+  vars:
+    release_codename: "{{ ansible_distribution_release }}"
+  template:
     src: docker.list
     dest: /etc/apt/sources.list.d
     mode: 0644

--- a/templates/docker.list
+++ b/templates/docker.list
@@ -1,0 +1,1 @@
+deb [arch=amd64] https://download.docker.com/linux/debian {{ release_codename }} stable


### PR DESCRIPTION
While testing a different project on Debian Buster, I noticed that Docker was failing to be installed properly- I was getting this error on a Buster instance:
```
$ docker-compose -h
Traceback (most recent call last):
  File "/usr/local/bin/docker-compose", line 6, in <module>
    from compose.cli.main import main
  File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 17, in <module>
    import docker
  File "/usr/local/lib/python2.7/dist-packages/docker/__init__.py", line 2, in <module>
    from .api import APIClient
  File "/usr/local/lib/python2.7/dist-packages/docker/api/__init__.py", line 2, in <module>
    from .client import APIClient
  File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 10, in <module>
    from .build import BuildApiMixin
  File "/usr/local/lib/python2.7/dist-packages/docker/api/build.py", line 6, in <module>
    from .. import auth
  File "/usr/local/lib/python2.7/dist-packages/docker/auth.py", line 9, in <module>
    from .utils import config
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/__init__.py", line 3, in <module>
    from .decorators import check_resource, minimum_version, update_headers
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/decorators.py", line 4, in <module>
    from . import utils
  File "/usr/local/lib/python2.7/dist-packages/docker/utils/utils.py", line 13, in <module>
    from .. import tls
  File "/usr/local/lib/python2.7/dist-packages/docker/tls.py", line 5, in <module>
    from .transport import SSLHTTPAdapter
  File "/usr/local/lib/python2.7/dist-packages/docker/transport/__init__.py", line 3, in <module>
    from .ssladapter import SSLHTTPAdapter
  File "/usr/local/lib/python2.7/dist-packages/docker/transport/ssladapter.py", line 23, in <module>
    from backports.ssl_match_hostname import match_hostname
ImportError: No module named ssl_match_hostname
``` 

To fix it, I ensured that this role pulls Docker from the correct (Debian release-specific) repository (see commit https://github.com/cisagov/ansible-role-docker/commit/ea24f51e568bbb665807a06d1fd4706f31072aca).

This PR also includes the latest upstream commits from [skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role).