### PR TITLE
Skip cache update task when checking for idempotence

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -16,30 +16,26 @@
       apt:
         update_cache: yes
 
-# The Fedora Docker images we are using
-# (geerlingguy/docker-fedora32-ansible:latest and
-# cisagov/docker-fedora33-ansible:latest) require the dnf cache to
-# be updated before they can successfully install anything.  At least,
-# they keep giving this error if I don't update the dnf cache:
+# When installing packages during later steps, the Fedora Docker
+# images we are using (geerlingguy/docker-fedora32-ansible:latest and
+# cisagov/docker-fedora33-ansible:latest) can throw sporadic errors
+# like: "No such file or directory:
+# '/var/cache/dnf/metadata_lock.pid'".
 #
-# No such file or directory: '/var/cache/dnf/metadata_lock.pid'
-#
-# Related to this, I see sporadic failures when updating the DNF cache.
-# The fix is to ensure that systemd finishes initializing before updating
-# the cache.  For details see:
+# The fix is to ensure that systemd finishes initializing before
+# continuing on to the converge tasks.  For details see:
 # https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
-- name: Update dnf cache (Fedora)
+- name: Wait for systemd to complete initialization (Fedora)
   hosts: os_Fedora
-  pre_tasks:
-    - name: Wait for systemd to complete initialization. # noqa 303
+  tasks:
+    - name: Wait for systemd to complete initialization # noqa 303
       command: systemctl is-system-running
       register: systemctl_status
       until: "'running' in systemctl_status.stdout"
       retries: 30
       delay: 5
       when: ansible_service_mgr == 'systemd'
-      changed_when: false
-  tasks:
-    - name: Update dnf cache
-      dnf:
-        update_cache: yes
+      # This task always runs, no matter what, so let's ignore this
+      # task when running the idempotence check.
+      tags:
+        - molecule-idempotence-notest

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -22,3 +22,7 @@
 - name: Update the cache with the Docker goodness (Debian)
   package:
     update_cache: yes
+  # This cache update can cause idempotence to fail, so tell molecule
+  # to ignore any changes this task produces when testing idempotence.
+  tags:
+    - molecule-idempotence-notest


### PR DESCRIPTION
## 🗣 Description

This pull request:
* Adds a tag that causes any changes by the Debian cache update task to be ignored when verifying idempotence.  This task is necessary but not necessarily idempotent.
* Cleans up the `prepare.yml` playbook a bit, removing the DNF cache update that does nothing.

## 💭 Motivation and Context

I have seen this Ansible role and others that contain it as a dependency fail molecule testing because of the Debian cache update task, so it makes a lot of sense to make the tagging change.  While I was doing that I noticed that the `prepare.yml` playbook was not as clean as it could be, so I went ahead and took care of that as well.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
