### PR TITLE
Remove support for Ubuntu Xenial

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -31,7 +31,9 @@ galaxy_info:
         - 33
     - name: Ubuntu
       versions:
-        - xenial
+        # Xenial only has Python 3.5 and pip 8, and these antiquated
+        # versions cause issues.
+        # - xenial
         - bionic
         - focal
   role_name: docker

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -59,14 +59,14 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_bionic_systemd
+  - name: ubuntu_xenial_systemd
     image: geerlingguy/docker-ubuntu1604-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_xenial_systemd
+  - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -59,13 +59,15 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     command: /lib/systemd/systemd
     pre_build_image: yes
-  - name: ubuntu_xenial_systemd
-    image: geerlingguy/docker-ubuntu1604-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
+  # Xenial only has Python 3.5 and pip 8, and these antiquated
+  # versions cause issues.
+  # - name: ubuntu_xenial_systemd
+  #   image: geerlingguy/docker-ubuntu1604-ansible:latest
+  #   privileged: yes
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   command: /lib/systemd/systemd
+  #   pre_build_image: yes
   - name: ubuntu_bionic_systemd
     image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: yes

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -53,7 +53,7 @@ platforms:
     command: /lib/systemd/systemd
     pre_build_image: yes
   - name: fedora33_systemd
-    image: cisagov/docker-fedora33-ansible:latest
+    image: geerlingguy/docker-fedora33-ansible:latest
     privileged: yes
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for Ubuntu Xenial in this Ansible role.

## 💭 Motivation and Context ##

The Ubuntu Xenial GitHub Action build for this Ansible role started failing when I merged #30.  Digging into why, I found that the problem was due to Ubuntu Xenial only offering version 8 of `pip`.  (`pip` is currently at version 20.  Xenial also only offers version 3.5 of Python.)  The old version of `pip` causes an error when installing the `docker-compose` package, and even if I update `pip` the `docker-compose` package refuses to install under Python 3.5.  Since these antiquated versions of Python and `pip` are causing problems, it makes sense to drop support for Xenial.

## 🧪 Testing ##

All pre-commit hooks and molecule tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
