### PR TITLE
Fix broken Debian 9 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ This role uses the `package` Ansible module, so [its
 requirements](https://docs.ansible.com/ansible/latest/modules/package_module.html#requirements)
 apply.
 
-This role also depends on the
-[cisagov/ansible-role-pip](https://github.com/cisagov/ansible-role-pip)
-Ansible role.
-
 ## Role Variables ##
 
 None.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -37,7 +37,3 @@ galaxy_info:
         - bionic
         - focal
   role_name: docker
-
-dependencies:
-  - src: https://github.com/cisagov/ansible-role-pip
-    name: pip

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -37,3 +37,7 @@ galaxy_info:
         - bionic
         - focal
   role_name: docker
+
+dependencies:
+  - src: https://github.com/cisagov/ansible-role-backports
+    name: backports

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,6 @@
 ---
+- src: https://github.com/cisagov/ansible-role-backports
+  name: backports
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
 - src: https://github.com/cisagov/ansible-role-python

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,26 +16,37 @@ def test_packages(host):
     """Test that the appropriate packages were installed."""
     distribution = host.system_info.distribution
     codename = host.system_info.codename
+
+    # Docker package
     if (distribution == "debian" and codename is None) or distribution == "kali":
         # Debian Bullseye is not yet supported by the official Docker
         # package repo
+        #
+        # https://docs.docker.com/engine/install/debian/
         assert host.package("docker.io").is_installed
     elif distribution == "fedora":
+        # Only Moby is available for Feodra 32 and 33
+        #
+        # https://docs.docker.com/engine/install/fedora/
         assert host.package("moby-engine").is_installed
     else:
         assert host.package("docker-ce").is_installed
+
+    # docker-compose package
+    assert host.package("docker-compose").is_installed
+
+    # Docker python library
+    if distribution == "debian" and codename == "stretch":
+        # Our Stretch AMIs are still using Python 2
+        assert host.package("python-docker").is_installed
+    else:
+        assert host.package("python3-docker").is_installed
 
 
 @pytest.mark.parametrize("svc", ["docker"])
 def test_services(host, svc):
     """Test that the services were enabled."""
     assert host.service(svc).is_enabled
-
-
-@pytest.mark.parametrize("pkg", ["docker-compose", "docker"])
-def test_pip_packages(host, pkg):
-    """Test that the appropriate pip packages were installed."""
-    assert pkg in host.pip_package.get_packages(pip_path="pip3")
 
 
 @pytest.mark.parametrize("command", ["docker-compose version"])

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     - ansible_os_family == "Debian"
     # The docker-ce PPA does not yet support Debian Bullseye
     # (identified as version NA)
-    - not (ansible_distribution == "Debian" and ansible_distribution_version == "NA")
+    - not (ansible_distribution == "Debian" and ansible_distribution_version|lower == "na")
     # By extension, it does not yet support Kali either.
     - ansible_distribution != "Kali"
 
@@ -20,9 +20,23 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install docker, docker-compose, and the Docker Python library
+- name: >
+    Install docker, docker-compose, and the Docker Python library (not
+    Debian Stretch)
   package:
     name: "{{ package_names }}"
+  when:
+    - ansible_distribution != "Debian" or ansible_distribution_release|lower != "stretch"
+
+- name: >
+    Install docker, docker-compose, and the Docker Python library (Debian
+    Stretch)
+  package:
+    default_release: "{{ ansible_distribution_release }}-backports"
+    name: "{{ package_names }}"
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_release|lower == "stretch"
 
 # Unless you do this, systemd can sometimes get confused when you try
 # to start a service you just installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 # docker_image, docker_compose, etc.
 - name: Install docker-compose and the docker python library
   pip:
-    executable: pip3
+    executable: "{{ pip_executable }}"
     name:
       - docker[tls]
       - docker-compose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-# tasks file for docker
-
 - name: Load setup tasks file for adding the official Docker PPA to Debian
   include: setup_Debian.yml
   when:
@@ -22,7 +20,7 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install docker
+- name: Install docker, docker-compose, and the Docker Python library
   package:
     name: "{{ package_names }}"
 
@@ -37,12 +35,3 @@
   service:
     name: docker
     enabled: yes
-
-# The docker python library is needed when using the Ansible modules
-# docker_image, docker_compose, etc.
-- name: Install docker-compose and the docker python library
-  pip:
-    executable: "{{ pip_executable }}"
-    name:
-      - docker[tls]
-      - docker-compose

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -1,5 +1,5 @@
 ---
-# setup file for Debian
+# Setup for installing Docker on Debian from the official Docker repo
 
 - name: Install prerequisites so apt can use a repo over HTTPS (Debian)
   package:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,6 @@
 ---
-# vars file for Debian
-
-# The packages to install
+# The system packages to install
 package_names:
   - docker-ce
-
-# The pip executable to use
-pip_executable: pip3
+  - docker-compose
+  - python3-docker

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,6 @@
 # The packages to install
 package_names:
   - docker-ce
+
+# The pip executable to use
+pip_executable: pip3

--- a/vars/Debian_9.12.yml
+++ b/vars/Debian_9.12.yml
@@ -1,0 +1,1 @@
+Debian_9.yml

--- a/vars/Debian_9.13.yml
+++ b/vars/Debian_9.13.yml
@@ -1,0 +1,1 @@
+Debian_9.yml

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,9 +1,6 @@
 ---
-# vars file for Debian 9
-
-# The packages to install
+# The system packages to install
 package_names:
   - docker-ce
-
-# The pip executable to use
-pip_executable: pip
+  - docker-compose
+  - python-docker

--- a/vars/Debian_9.yml
+++ b/vars/Debian_9.yml
@@ -1,0 +1,9 @@
+---
+# vars file for Debian 9
+
+# The packages to install
+package_names:
+  - docker-ce
+
+# The pip executable to use
+pip_executable: pip

--- a/vars/Debian_NA.yml
+++ b/vars/Debian_NA.yml
@@ -4,3 +4,6 @@
 # The packages to install
 package_names:
   - docker.io
+
+# The pip executable to use
+pip_executable: pip3

--- a/vars/Debian_NA.yml
+++ b/vars/Debian_NA.yml
@@ -1,9 +1,11 @@
 ---
-# vars file for Debian Bullseye (AKA NA)
-
-# The packages to install
+# The system packages to install
+#
+# Note that Debian Bullseye is not yet supported by the official
+# Docker package repo.
+#
+# https://docs.docker.com/engine/install/debian/
 package_names:
   - docker.io
-
-# The pip executable to use
-pip_executable: pip3
+  - docker-compose
+  - python3-docker

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,15 +1,14 @@
 ---
-# vars file for RedHat
-
-# The packages to install
+# The system packages to install
 #
 # Note that docker-ce is not currently available on any of our supported
 # Fedora platforms (32 and 33), so we install the next best thing, which
 # is moby-engine.  See https://src.fedoraproject.org/rpms/moby-engine
 # From a usage standpoint, it is transparent, as "docker ..." commands
 # are accepted and passed to moby-engine.
+#
+# https://docs.docker.com/engine/install/fedora/
 package_names:
+  - docker-compose
   - moby-engine
-
-# The pip executable to use
-pip_executable: pip3
+  - python3-docker

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,3 +10,6 @@
 # are accepted and passed to moby-engine.
 package_names:
   - moby-engine
+
+# The pip executable to use
+pip_executable: pip3

--- a/vars/Ubuntu_16.04.yml
+++ b/vars/Ubuntu_16.04.yml
@@ -1,9 +1,0 @@
----
-# vars file for Ubuntu 16.04
-
-# The packages to install
-package_names:
-  - docker-ce
-  # For some reason this dev package is missing when we try to build
-  # the wheel for docker-compose
-  - libssl-dev


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes the Debian 9 builds that recently started breaking.

## 💭 Motivation and Context ##

Some [Debian 9](https://github.com/cisagov/ansible-role-docker/actions/runs/391949880) [builds](https://github.com/cisagov/ansible-role-guacamole/runs/1475555772) recently started breaking.  I investigated and found that the failures were due to:
1. The use of `pip` to install [`docker-compose`](https://pypi.org/project/docker-compose/) and [`docker[tls]`](https://pypi.org/project/docker/) Python libraries
2. The dropping of Python 2 support from some Python libraries downstream of  [`docker-compose`](https://pypi.org/project/docker-compose/) and [`docker[tls]`](https://pypi.org/project/docker/)

The simplest solution is to just let the system package manager handle the dependencies.  This also fits with our more recent ideas about `pip` dependency management:
* Let the system package manager manage system Python dependencies
* Use `pyenv` if not using the system Python, and in that case let `pip` manage the Python dependencies

One complication that @mcdonnnj pointed out is that the version of `python-docker` installed from the usual Debian Stretch package repositories is several major versions behind the latest.  Therefore we pull that package from [`stretch-backports`](https://backports.debian.org/) instead.

## 🧪 Testing ##

All molecule tests and pre-commit hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
