### PR TITLE
Add docker-compose-plugin package for Debian

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -90,6 +90,11 @@ def test_commands(host):
     codename = host.system_info.codename
 
     if distribution in ["debian"]:
+        # The difference between the two Debian packages
+        # docker-compose and docker-compose-plugin is that
+        # docker-compose provides a docker-compose command, while the
+        # docker-compose-plugin package provides docker compose
+        # functionality to the docker command.
         if codename in ["buster", "bullseye"]:
             assert host.run("docker compose version").rc == 0
         elif codename in ["stretch", "bookworm"]:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -35,7 +35,6 @@ def test_packages(host):
                     host.package(pkg).is_installed
                     for pkg in [
                         "docker-ce",
-                        "docker-compose",
                         "docker-compose-plugin",
                         "python3-docker",
                     ]
@@ -63,7 +62,6 @@ def test_packages(host):
                 host.package(pkg).is_installed
                 for pkg in [
                     "docker-ce",
-                    "docker-compose",
                     "docker-compose-plugin",
                     "python3-docker",
                 ]
@@ -94,27 +92,14 @@ def test_commands(host, command):
 
     if distribution in ["debian"]:
         if codename in ["buster", "bullseye"]:
-            assert all(
-                [
-                    host.run(cmd).rc == 0
-                    for cmd in ["docker compose version", "docker-compose version"]
-                ]
-            )
+            assert host.run("docker compose version").rc == 0
         elif codename in ["stretch", "bookworm"]:
-            assert all([host.run(cmd).rc == 0 for cmd in ["docker-compose version"]])
+            assert host.run("docker-compose version").rc == 0
         else:
             assert False, f"Unknown codename {codename}"
-    elif distribution in ["kali"]:
-        assert all([host.run(cmd).rc == 0 for cmd in ["docker-compose version"]])
+    elif distribution in ["amzn", "fedora", "kali"]:
+        assert host.run("docker-compose version").rc == 0
     elif distribution in ["ubuntu"]:
-        assert all(
-            [
-                host.run(cmd).rc == 0
-                for cmd in ["docker compose version", "docker-compose version"]
-            ]
-        )
-    elif distribution in ["amzn", "fedora"]:
-        assert all([host.run(cmd).rc == 0 for cmd in ["docker-compose version"]])
+        assert host.run("docker compose version").rc == 0
     else:
         assert False, f"Unknown distribution {distribution}"
-    assert host.run(command).rc == 0

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -84,8 +84,7 @@ def test_services(host, svc):
     assert host.service(svc).is_enabled
 
 
-@pytest.mark.parametrize("command", ["docker-compose version"])
-def test_commands(host, command):
+def test_commands(host):
     """Test that appropriate commands are available."""
     distribution = host.system_info.distribution
     codename = host.system_info.codename

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_packages(host):
         if codename in ["stretch"]:
             assert all(
                 [
-                    host.package(pkg)
+                    host.package(pkg).is_installed
                     for pkg in [
                         "docker-ce",
                         "docker-compose",
@@ -32,7 +32,7 @@ def test_packages(host):
         elif codename in ["buster", "bullseye"]:
             assert all(
                 [
-                    host.package(pkg)
+                    host.package(pkg).is_installed
                     for pkg in [
                         "docker-ce",
                         "docker-compose",
@@ -44,7 +44,7 @@ def test_packages(host):
         elif codename in ["bookworm"]:
             assert all(
                 [
-                    host.package(pkg)
+                    host.package(pkg).is_installed
                     for pkg in ["docker.io", "docker-compose", "python3-docker"]
                 ]
             )
@@ -53,14 +53,14 @@ def test_packages(host):
     elif distribution in ["kali"]:
         assert all(
             [
-                host.package(pkg)
+                host.package(pkg).is_installed
                 for pkg in ["docker.io", "docker-compose", "python3-docker"]
             ]
         )
     elif distribution in ["ubuntu"]:
         assert all(
             [
-                host.package(pkg)
+                host.package(pkg).is_installed
                 for pkg in [
                     "docker-ce",
                     "docker-compose",
@@ -72,7 +72,7 @@ def test_packages(host):
     elif distribution in ["amzn", "fedora"]:
         assert all(
             [
-                host.package(pkg)
+                host.package(pkg).is_installed
                 for pkg in ["docker-compose", "moby-engine", "python3-docker"]
             ]
         )

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,4 +3,5 @@
 package_names:
   - docker-ce
   - docker-compose
+  - docker-compose-plugin
   - python3-docker

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,5 @@
 # The system packages to install
 package_names:
   - docker-ce
-  - docker-compose
   - docker-compose-plugin
   - python3-docker

--- a/vars/Debian_bookworm.yml
+++ b/vars/Debian_bookworm.yml
@@ -1,7 +1,7 @@
 ---
 # The system packages to install
 #
-# Note that Debian Bullseye is not yet supported by the official
+# Note that Debian Bookworm is not yet supported by the official
 # Docker package repo.
 #
 # https://docs.docker.com/engine/install/debian/

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,6 +1,8 @@
 ---
 # The system packages to install
 package_names:
+  # Note that the docker-compose-plugin package is unavailable for
+  # Debian stretch.
   - docker-ce
   - docker-compose
   - python-docker

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -2,7 +2,7 @@
 # The system packages to install
 package_names:
   # Note that the docker-compose-plugin package is unavailable for
-  # Debian stretch.
+  # Debian Stretch.
   - docker-ce
   - docker-compose
   - python-docker


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `docker-compose-plugin` package for Debian instances.

## 💭 Motivation and context ##

[The assessors require `docker compose` version 2.2.3 or later](https://jira.ceil.cyber.dhs.gov/projects/CAL/queues/custom/20/CAL-18104).  The `docker-compose` package currently supports a `1.x` version, while the `docker-compose-plugin` package supports a `2.x` version; therefore, the assessors' needs dictate that we install the `docker-compose-plugin` package.

The difference between the two Debian packages is that `docker-compose` provides a `docker-compose` command, while the `docker-compose-plugin` package provides `docker compose` functionality to the `docker` command.

## 🧪 Testing ##

All automated tests pass.  These changes were also tested successfully via the manual testing done in cisagov/docker-packer#41.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.