### PR TITLE
Use official Docker packages where possible

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -38,6 +38,7 @@ def test_packages(host):
                         "docker-ce",
                         "docker-ce-cli",
                         "docker-compose-plugin",
+                        "pass",
                         "python3-docker",
                     ]
                 ]
@@ -67,6 +68,7 @@ def test_packages(host):
                     "docker-ce",
                     "docker-ce-cli",
                     "docker-compose-plugin",
+                    "pass",
                     "python3-docker",
                 ]
             ]

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -34,7 +34,9 @@ def test_packages(host):
                 [
                     host.package(pkg).is_installed
                     for pkg in [
+                        "containerd.io",
                         "docker-ce",
+                        "docker-ce-cli",
                         "docker-compose-plugin",
                         "python3-docker",
                     ]
@@ -61,7 +63,9 @@ def test_packages(host):
             [
                 host.package(pkg).is_installed
                 for pkg in [
+                    "containerd.io",
                     "docker-ce",
+                    "docker-ce-cli",
                     "docker-compose-plugin",
                     "python3-docker",
                 ]

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -58,7 +58,7 @@ def test_packages(host):
                 for pkg in ["docker.io", "docker-compose", "python3-docker"]
             ]
         )
-    elif distribution in ["ubuntu"]:
+    elif distribution in ["fedora", "ubuntu"]:
         assert all(
             [
                 host.package(pkg).is_installed
@@ -71,7 +71,7 @@ def test_packages(host):
                 ]
             ]
         )
-    elif distribution in ["amzn", "fedora"]:
+    elif distribution in ["amzn"]:
         assert all(
             [
                 host.package(pkg).is_installed
@@ -105,9 +105,9 @@ def test_commands(host):
             assert host.run("docker-compose version").rc == 0
         else:
             assert False, f"Unknown codename {codename}"
-    elif distribution in ["amzn", "fedora", "kali"]:
+    elif distribution in ["amzn", "kali"]:
         assert host.run("docker-compose version").rc == 0
-    elif distribution in ["ubuntu"]:
+    elif distribution in ["fedora", "ubuntu"]:
         assert host.run("docker compose version").rc == 0
     else:
         assert False, f"Unknown distribution {distribution}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,12 @@
     # By extension, it does not yet support Kali either.
     - ansible_distribution != "Kali"
 
+- name: Load setup tasks file for adding the official Docker repo to Fedora
+  ansible.builtin.include_tasks:
+    file: setup_Fedora.yml
+  when:
+    - ansible_distribution == "Fedora"
+
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -1,6 +1,16 @@
 ---
 # Setup for installing Docker on Debian from the official Docker repo
 
+- name: Uninstall non-official versions of packages
+  ansible.builtin.package:
+    name:
+      - containerd
+      - docker
+      - docker-engine
+      - docker.io
+      - runc
+    state: absent
+
 - name: Install prerequisites so apt can use a repo over HTTPS (Debian)
   ansible.builtin.package:
     name:
@@ -8,6 +18,7 @@
       - ca-certificates
       - curl
       - gnupg2
+      - lsb-release
       - software-properties-common
 
 - name: Get official Docker repo GPG key (Debian)

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -1,7 +1,7 @@
 ---
 # Setup for installing Docker on Debian from the official Docker repo
 #
-# https://docs.docker.com/engine/install/fedora/
+# https://docs.docker.com/engine/install/debian/
 
 - name: Uninstall non-official versions of packages (Debian)
   ansible.builtin.package:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -1,7 +1,9 @@
 ---
 # Setup for installing Docker on Debian from the official Docker repo
+#
+# https://docs.docker.com/engine/install/fedora/
 
-- name: Uninstall non-official versions of packages
+- name: Uninstall non-official versions of packages (Debian)
   ansible.builtin.package:
     name:
       - containerd
@@ -28,7 +30,6 @@
 - name: Add the official Docker repo (Debian)
   ansible.builtin.apt_repository:
     repo: deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
-    state: present
 
 - name: Update the cache with the Docker goodness (Debian)
   ansible.builtin.package:

--- a/tasks/setup_Fedora.yml
+++ b/tasks/setup_Fedora.yml
@@ -1,0 +1,46 @@
+---
+# Setup for installing Docker on Fedora from the official Docker repo
+#
+# https://docs.docker.com/engine/install/fedora/
+
+- name: Uninstall non-official versions of packages (Fedora)
+  ansible.builtin.package:
+    name:
+      - docker
+      - docker-client
+      - docker-client-latest
+      - docker-common
+      - docker-latest
+      - docker-latest-logrotate
+      - docker-logrotate
+      # The following package is listed in the Docker documentation,
+      # but breaks idempotence if uninstalled.
+      # - docker-selinux
+      - docker-engine-selinux
+      - docker-engine
+    state: absent
+
+- name: Install prerequisites for dnf (Fedora)
+  ansible.builtin.package:
+    name:
+      - dnf-plugins-core
+
+- name: Add the official Docker repo (Fedora)
+  # If a ansible.builtin.dnf_repository Ansible module is ever created
+  # then that should be used instead; unfortunately, no such module
+  # yet exists.
+  ansible.builtin.command:
+    argv:
+      - dnf
+      - config-manager
+      - --add-repo
+      - https://download.docker.com/linux/fedora/docker-ce.repo
+    creates: /etc/yum.repos.d/docker-ce.repo
+
+- name: Update the cache with the Docker goodness (Fedora)
+  ansible.builtin.package:
+    update_cache: yes
+  # This cache update can cause idempotence to fail, so tell molecule
+  # to ignore any changes this task produces when testing idempotence.
+  tags:
+    - molecule-idempotence-notest

--- a/tasks/setup_Fedora.yml
+++ b/tasks/setup_Fedora.yml
@@ -26,7 +26,7 @@
       - dnf-plugins-core
 
 - name: Add the official Docker repo (Fedora)
-  # If a ansible.builtin.dnf_repository Ansible module is ever created
+  # If an ansible.builtin.dnf_repository Ansible module is ever created
   # then that should be used instead; unfortunately, no such module
   # yet exists.
   ansible.builtin.command:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,4 +7,9 @@ package_names:
   - docker-ce
   - docker-ce-cli
   - docker-compose-plugin
+  # This package is required to avoid an issue with docker compose
+  # pull.  See, for example:
+  # - https://github.com/docker/compose/issues/6023
+  # - https://docs.docker.com/engine/reference/commandline/login/
+  - pass
   - python3-docker

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,7 +8,8 @@ package_names:
   - docker-ce-cli
   - docker-compose-plugin
   # This package is required to avoid an issue with docker compose
-  # pull.  See, for example:
+  # pull.  See the following for more information:
+  # - https://github.com/docker/compose/issues/9560
   # - https://github.com/docker/compose/issues/6023
   # - https://docs.docker.com/engine/reference/commandline/login/
   - pass

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,7 @@
 ---
 # The system packages to install
+#
+# https://docs.docker.com/engine/install/debian/
 package_names:
   - containerd.io
   - docker-ce

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,8 @@
 ---
 # The system packages to install
 package_names:
+  - containerd.io
   - docker-ce
+  - docker-ce-cli
   - docker-compose-plugin
   - python3-docker

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,1 @@
+Debian.yml

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,13 +1,11 @@
 ---
 # The system packages to install
 #
-# Note that docker-ce is not currently available on any of our supported
-# Fedora platforms (32 and 33), so we install the next best thing, which
-# is moby-engine.  See https://src.fedoraproject.org/rpms/moby-engine
+# Note that docker-ce is not currently available on Amazon Linux 2, so
+# we install the next best thing, which is moby-engine.
+#
 # From a usage standpoint, it is transparent, as "docker ..." commands
 # are accepted and passed to moby-engine.
-#
-# https://docs.docker.com/engine/install/fedora/
 package_names:
   - docker-compose
   - moby-engine


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to install the official Docker packages wherever possible.

## 💭 Motivation and context ##

We weren't installing the official Docker packages on Fedora, but with these changes we do.  This makes the Ansible role more useful and resolves #62.

## 🧪 Testing ##

All automated tests pass.

While testing these changes we discovered that `docker compose pull` failed due to an inability to login on some platforms.  We are able to work around this issue by installing [the `pass` software package](https://www.passwordstore.org/), and @mcdonnnj created docker/compose#9560 to ensure that the `docker compose` team is aware of the issue.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.