### PR TITLE
Remove references to Debian Stretch

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
         - "{{ role_path }}/vars"
 
 - name: >
-    Install docker, docker-compose, and the Docker Python library
+    Install Docker, Docker Compose, and the Docker Python library
   ansible.builtin.package:
     name: "{{ package_names }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,22 +28,9 @@
         - "{{ role_path }}/vars"
 
 - name: >
-    Install docker, docker-compose, and the Docker Python library (not
-    Debian Stretch)
+    Install docker, docker-compose, and the Docker Python library
   ansible.builtin.package:
     name: "{{ package_names }}"
-  when:
-    - ansible_distribution != "Debian" or ansible_distribution_release != "stretch"
-
-- name: >
-    Install docker, docker-compose, and the Docker Python library (Debian
-    Stretch)
-  ansible.builtin.package:
-    default_release: "{{ ansible_distribution_release }}-backports"
-    name: "{{ package_names }}"
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_distribution_release == "stretch"
 
 # Unless you do this, systemd can sometimes get confused when you try
 # to start a service you just installed


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes a few remaining references to Debian Stretch.

## 💭 Motivation and context ##

Debian Stretch is no longer supported by this Ansible role.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.