### PR TITLE
Remove installation of nonexistent package

### DIFF
--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -13,38 +13,42 @@
       - runc
     state: absent
 
-- name: Install prerequisites so apt can use a repo over HTTPS (Debian)
-  ansible.builtin.package:
-    name:
-      - apt-transport-https
-      - ca-certificates
-      - curl
-      - gnupg2
-      - lsb-release
-      - software-properties-common
-
-- name: Get official Docker repo GPG key (Debian, not Kali)
-  ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+- name: Add official Docker repo (Debian, not Kali)
   when:
     - ansible_distribution | lower != "kali"
+  block:
+    - name: Install prerequisites so apt can use a repo over HTTPS (Debian, not Kali)
+      ansible.builtin.package:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg2
+          - lsb-release
+          - software-properties-common
+    - name: Get official Docker repo GPG key (Debian, not Kali)
+      ansible.builtin.apt_key:
+        url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    - name: Add the official Docker repo (Debian, not Kali)
+      ansible.builtin.apt_repository:
+        repo: deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
 
-# Use Debian Bookworm for Kali
-- name: Get official Docker repo GPG key (Kali)
-  ansible.builtin.apt_key:
-    url: https://download.docker.com/linux/debian/gpg
+- name: Add official Docker repo (Kali)
   when:
     - ansible_distribution | lower == "kali"
-
-- name: Add the official Docker repo (Debian, not Kali)
-  ansible.builtin.apt_repository:
-    repo: deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
-  when:
-    - ansible_distribution | lower != "kali"
-
-# Use Debian Bookworm for Kali
-- name: Add the official Docker repo (Kali)
-  ansible.builtin.apt_repository:
-    repo: deb https://download.docker.com/linux/debian bookworm stable
-  when:
-    - ansible_distribution | lower == "kali"
+  block:
+    - name: Install prerequisites so apt can use a repo over HTTPS (Kali)
+      ansible.builtin.package:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg2
+          - lsb-release
+    # Use Debian Bookworm for Kali
+    - name: Get official Docker repo GPG key (Kali)
+      ansible.builtin.apt_key:
+        url: https://download.docker.com/linux/debian/gpg
+    - name: Add the official Docker repo (Kali)
+      ansible.builtin.apt_repository:
+        repo: deb https://download.docker.com/linux/debian bookworm stable


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the installation of a nonexistent package on Kali Linux.

## 💭 Motivation and context ##

The package `software-properties-common` [has been removed from Kali and Sid](https://tracker.debian.org/pkg/software-properties).  This was causing some [failed](https://github.com/cisagov/ansible-role-docker/actions/runs/11638721850) [APB builds](https://github.com/cisagov/ansible-role-pca-gophish-composition/actions/runs/11640615750).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.