### PR TITLE
Use a DEB822 repo for Kali

### DIFF
--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -45,10 +45,20 @@
           - curl
           - gnupg2
           - lsb-release
-    # Use Debian Bookworm for Kali
-    - name: Get official Docker repo GPG key (Kali)
-      ansible.builtin.apt_key:
-        url: https://download.docker.com/linux/debian/gpg
+    - name: Install prerequisites so apt can use DEB822 repos (Kali)
+      ansible.builtin.package:
+        name:
+          - python3-debian
     - name: Add the official Docker repo (Kali)
-      ansible.builtin.apt_repository:
-        repo: deb https://download.docker.com/linux/debian bookworm stable
+      ansible.builtin.deb822_repository:
+        components:
+          - stable
+        name: docker
+        signed_by: https://download.docker.com/linux/debian/gpg
+        suites:
+          - bookworm
+        uris:
+          - https://download.docker.com/linux/debian
+    - name: Update the package cache
+      ansible.builtin.apt:
+        update_cache: true


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Ansible role to use a DEB822 repo for Kali.

## 💭 Motivation and context ##

Kali recently updated to a version of the `apt` package that no longer provides the deprecated `apt-key` binary, so we cannot use `ansible.builtin.apt_key` to get the official Docker repo GPG key.  Rather than download the key with `ansible.builtin.get_url` and create an old-style repo, I chose to upgrade to a newer-style DEB822 repo.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.