### PR TITLE
Use DEB822 repo for all Debian platforms except for Buster

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Update the apt package cache
+  ansible.builtin.apt:
+    update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: >
     Install Docker, Docker Compose, and the Docker Python library
   ansible.builtin.package:
-    name: "{{ package_names }}"
+    name: "{{ docker_prerequisites }}"
 
 # Amazon Linux 2023 does not (yet?) offer docker-compose or the
 # Docker Compose plugin, so we grab it from GitHub:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,6 @@
 - name: Systemd daemon-reload
   ansible.builtin.systemd:
     daemon_reload: true
-  when: ansible_service_mgr == "systemd"
 
 - name: Enable docker
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Load var file based on the OS type
+  ansible.builtin.include_vars:
+    file: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+
 - name: Load setup tasks file for adding the official Docker repo
   ansible.builtin.include_tasks:
     file: "{{ lookup('first_found', params) }}"
@@ -14,18 +26,6 @@
     # Note that we only need to do this for all Debian-based OSs and
     # Fedora.
     - ansible_os_family == "Debian" or ansible_distribution == "Fedora"
-
-- name: Load var file with package names based on the OS type
-  ansible.builtin.include_vars:
-    file: "{{ lookup('first_found', params) }}"
-  vars:
-    params:
-      files:
-        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
-      paths:
-        - "{{ role_path }}/vars"
 
 - name: >
     Install Docker, Docker Compose, and the Docker Python library

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -28,7 +28,7 @@
         url: https://download.docker.com/linux/{{ apt_distro }}/gpg
     - name: Add the official Docker repo
       ansible.builtin.apt_repository:
-        repo: deb https://download.docker.com/linux/{{ apt_distro | lower }} {{ apt_distro_release }} stable
+        repo: deb https://download.docker.com/linux/{{ apt_distro }} {{ apt_distro_release }} stable
     # ansible.builtin.apt_repository updates the package cache so
     # there is no need to do it explicitly.
 

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -13,32 +13,34 @@
       - runc
     state: absent
 
-- name: Add official Docker repo (Debian, not Kali)
+- name: Install prerequisites so apt can use a repo over HTTPS
+  ansible.builtin.package:
+    name: "{{ apt_over_https_prerequisites }}"
+
+# Debian Buster does not support DEB822 repos, so we have to treat it
+# as a special case.
+- name: Add official Docker repo (Debian Buster)
   when:
-    - ansible_distribution | lower != "kali"
+    - ansible_distribution_release == "buster"
   block:
-    - name: Install prerequisites so apt can use a repo over HTTPS (Debian, not Kali)
-      ansible.builtin.package:
-        name: "{{ apt_over_https_prerequisites }}"
-    - name: Get official Docker repo GPG key (Debian, not Kali)
+    - name: Get official Docker repo GPG key
       ansible.builtin.apt_key:
         url: https://download.docker.com/linux/{{ apt_distro }}/gpg
-    - name: Add the official Docker repo (Debian, not Kali)
+    - name: Add the official Docker repo
       ansible.builtin.apt_repository:
         repo: deb https://download.docker.com/linux/{{ apt_distro | lower }} {{ apt_distro_release }} stable
+    # ansible.builtin.apt_repository updates the package cache so
+    # there is no need to do it explicitly.
 
-- name: Add official Docker repo (Kali)
+- name: Add official Docker repo
   when:
-    - ansible_distribution | lower == "kali"
+    - ansible_distribution_release != "buster"
   block:
-    - name: Install prerequisites so apt can use a repo over HTTPS (Kali)
-      ansible.builtin.package:
-        name: "{{ apt_over_https_prerequisites }}"
-    - name: Install prerequisites so apt can use DEB822 repos (Kali)
+    - name: Install prerequisites so apt can use DEB822 repos
       ansible.builtin.package:
         name:
           - python3-debian
-    - name: Add the official Docker repo (Kali)
+    - name: Add the official Docker repo
       ansible.builtin.deb822_repository:
         components:
           - stable

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -19,13 +19,7 @@
   block:
     - name: Install prerequisites so apt can use a repo over HTTPS (Debian, not Kali)
       ansible.builtin.package:
-        name:
-          - apt-transport-https
-          - ca-certificates
-          - curl
-          - gnupg2
-          - lsb-release
-          - software-properties-common
+        name: "{{ apt_over_https_prerequisites }}"
     - name: Get official Docker repo GPG key (Debian, not Kali)
       ansible.builtin.apt_key:
         url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
@@ -39,12 +33,7 @@
   block:
     - name: Install prerequisites so apt can use a repo over HTTPS (Kali)
       ansible.builtin.package:
-        name:
-          - apt-transport-https
-          - ca-certificates
-          - curl
-          - gnupg2
-          - lsb-release
+        name: "{{ apt_over_https_prerequisites }}"
     - name: Install prerequisites so apt can use DEB822 repos (Kali)
       ansible.builtin.package:
         name:

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -22,10 +22,10 @@
         name: "{{ apt_over_https_prerequisites }}"
     - name: Get official Docker repo GPG key (Debian, not Kali)
       ansible.builtin.apt_key:
-        url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+        url: https://download.docker.com/linux/{{ apt_distro }}/gpg
     - name: Add the official Docker repo (Debian, not Kali)
       ansible.builtin.apt_repository:
-        repo: deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable
+        repo: deb https://download.docker.com/linux/{{ apt_distro | lower }} {{ apt_distro_release }} stable
 
 - name: Add official Docker repo (Kali)
   when:
@@ -43,11 +43,11 @@
         components:
           - stable
         name: docker
-        signed_by: https://download.docker.com/linux/debian/gpg
+        signed_by: https://download.docker.com/linux/{{ apt_distro }}/gpg
         suites:
-          - bookworm
+          - "{{ apt_distro_release }}"
         uris:
-          - https://download.docker.com/linux/debian
+          - https://download.docker.com/linux/{{ apt_distro }}
     - name: Update the package cache
       ansible.builtin.apt:
         update_cache: true

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -45,10 +45,20 @@
           - curl
           - gnupg2
           - lsb-release
-    # Use Debian Bookworm for Kali
-    - name: Get official Docker repo GPG key (Kali)
-      ansible.builtin.apt_key:
-        url: https://download.docker.com/linux/debian/gpg
+    - name: Install prerequisites so apt can use DEB822 repos (Kali)
+      ansible.builtin.package:
+        name:
+          - python3-debian
     - name: Add the official Docker repo (Kali)
-      ansible.builtin.apt_repository:
-        repo: deb https://download.docker.com/linux/debian bookworm stable
+      ansible.builtin.deb822_repository:
+        components:
+          - stable
+        name: docker
+        signed_by: https://download.docker.com/linux/debian/gpg
+        suites:
+          - bookworm
+        uris:
+          - https://download.docker.com/linux/debian
+    - name: Update the package cache
+      ansible.builtin.apt:
+        update_cache: true

--- a/tasks/setup_Debian.yml
+++ b/tasks/setup_Debian.yml
@@ -50,6 +50,11 @@
           - "{{ apt_distro_release }}"
         uris:
           - https://download.docker.com/linux/{{ apt_distro }}
-    - name: Update the package cache
-      ansible.builtin.apt:
-        update_cache: true
+      notify:
+        - Update the apt package cache
+    # We need the handler that updates the apt package cache to run
+    # now if it is necessary.  It is required by the parent playbook
+    # since it will attempt to install the packages from the new apt
+    # package repo.
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,6 +1,6 @@
 ---
-# The system packages to install.  Note that python-docker is not
-# available on Amazon Linux 2023:
+# The system packages required for Docker.  Note that python-docker is
+# not available on Amazon Linux 2023:
 # https://docs.aws.amazon.com/linux/al2023/release-notes/all-packages-al2023-20230419.html
-package_names:
+docker_prerequisites:
   - docker

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,11 @@
 ---
+# The Linux distribution to use when configuring a Debian repo.
+apt_distro: "{{ ansible_distribution | lower }}"
+
+# The release of the Linux distribution to use when configuring a
+# Debian repo.
+apt_distro_release: "{{ ansible_distribution_release }}"
+
 # The system packages required for apt-over-https.
 apt_over_https_prerequisites:
   - apt-transport-https

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,8 +1,8 @@
 ---
-# The system packages to install
+# The system packages required for Docker.
 #
 # https://docs.docker.com/engine/install/debian/
-package_names:
+docker_prerequisites:
   - containerd.io
   - docker-buildx-plugin
   - docker-ce

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,10 +1,16 @@
 ---
 # The Linux distribution to use when configuring a Debian repo.  Note
-# that we force Kali to use Debian Bookworm.
+# that we force Kali to use Debian Bookworm.  This is because Docker
+# does not provide an official package for Kali or Debian Testing (on
+# which Kali is based), but it does support Bookworm which is close
+# enough to work.
 apt_distro: debian
 
 # The release of the Linux distribution to use when configuring a
-# Debian repo.  Note that we force Kali to use Debian Bookworm.
+# Debian repo.  Note that we force Kali to use Debian Bookworm.  This
+# is because Docker does not provide an official package for Kali or
+# Debian Testing (on which Kali is based), but it does support
+# Bookworm which is close enough to work.
 apt_distro_release: bookworm
 
 # The system packages required for apt-over-https.

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -6,7 +6,9 @@ apt_over_https_prerequisites:
   - curl
   - gnupg2
   - lsb-release
-  - software-properties-common
+  # This package is not available on Kali, but whatever it installs
+  # seems to already be present.
+  # - software-properties-common
 
 # The system packages required for Docker.
 #

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -1,4 +1,12 @@
 ---
+# The Linux distribution to use when configuring a Debian repo.  Note
+# that we force Kali to use Debian Bookworm.
+apt_distro: debian
+
+# The release of the Linux distribution to use when configuring a
+# Debian repo.  Note that we force Kali to use Debian Bookworm.
+apt_distro_release: bookworm
+
 # The system packages required for apt-over-https.
 apt_over_https_prerequisites:
   - apt-transport-https


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the code to use a DEB822 repo for all Debian platforms except for Debian Buster.  This style of package repo is not supported by Debian Buster.

> [!NOTE]
> This PR is based on #83 and should be merged after that one.

## 💭 Motivation and context ##

This simplifies the Ansible code and treats Buster as the special case, not Kali.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.